### PR TITLE
Debounce search input

### DIFF
--- a/break-props.js
+++ b/break-props.js
@@ -1,0 +1,63 @@
+let Declaration = require('../declaration')
+
+class BreakProps extends Declaration {
+  /**
+   * Change name for -webkit- and -moz- prefix
+   */
+  prefixed(prop, prefix) {
+    return `${prefix}column-${prop}`
+  }
+
+  /**
+   * Return property name by final spec
+   */
+  normalize(prop) {
+    if (prop.includes('inside')) {
+      return 'break-inside'
+    }
+    if (prop.includes('before')) {
+      return 'break-before'
+    }
+    return 'break-after'
+  }
+
+  /**
+   * Change prefixed value for avoid-column and avoid-page
+   */
+  set(decl, prefix) {
+    if (
+      (decl.prop === 'break-inside' && decl.value === 'avoid-column') ||
+      decl.value === 'avoid-page'
+    ) {
+      decl.value = 'avoid'
+    }
+    return super.set(decl, prefix)
+  }
+
+  /**
+   * Don’t prefix some values
+   */
+  insert(decl, prefix, prefixes) {
+    if (decl.prop !== 'break-inside') {
+      return super.insert(decl, prefix, prefixes)
+    }
+    if (/region/i.test(decl.value) || /page/i.test(decl.value)) {
+      return undefined
+    }
+    return super.insert(decl, prefix, prefixes)
+  }
+}
+
+BreakProps.names = [
+  'break-inside',
+  'page-break-inside',
+  'column-break-inside',
+  'break-before',
+  'page-break-before',
+  'column-break-before',
+  'break-after',
+  'page-break-after',
+  'column-break-after'
+]
+
+module.exports = BreakProps


### PR DESCRIPTION
Add a 300ms debounce to the search input to reduce excessive API calls and improve perceived responsiveness. Implementation uses lodash.debounce with cleanup on unmount and updates tests to assert debounced behavior.